### PR TITLE
align reference data table columns to the left and ensure notes render correctly with whitespace preservation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to KonzertKatalog are documented here.
 
+---
+
+## [1.1.1] — 2026-04-26
+
+### Fixed
+
+- **Reference data tables** — all columns (Werke, Komponisten, Künstler,
+  Orchester, Spielorte) were right-aligned by default due to Quasar's table
+  default. Explicit `align: left` added to every content column. (#12, #16)
+- **Notes line breaks** — newlines entered in the Notizen textarea were
+  collapsed to a single line on the concert detail view. Both concert-level
+  and piece-level notes now render with `whitespace-pre-wrap`. (#13)
+
+
 ## [1.0.0] — 2026-04-25
 
 ### Breaking — Database schema change

--- a/app/views/concert_detail.py
+++ b/app/views/concert_detail.py
@@ -72,12 +72,12 @@ def concert_detail_page(concert_id: int) -> None:
                     if composer_name:
                         ui.label(composer_name).classes("text-sm text-gray-500")
                     if link.notes:
-                        ui.label(link.notes).classes("text-xs text-gray-400 italic")
+                        ui.label(link.notes).classes("text-xs text-gray-400 italic whitespace-pre-wrap")
 
     # ── Notes ────────────────────────────────────────────────────────────────
     if concert.notes:
         ui.label(t("notes")).classes("text-lg font-semibold mt-4 mb-1")
-        ui.label(concert.notes).classes("text-gray-700")
+        ui.label(concert.notes).classes("text-gray-700 whitespace-pre-wrap")
 
     # ── Attachments ──────────────────────────────────────────────────────────
     attachments_by_type: dict[str, list] = {t_val: [] for t_val in AttachmentType}

--- a/app/views/reference_data.py
+++ b/app/views/reference_data.py
@@ -91,7 +91,7 @@ def _delete_dialog(on_confirm: Callable[[], None]) -> ui.dialog:
 
 def _orchestras_panel(session) -> None:
     columns = [
-        {"name": "name", "label": t("col_orchestra"), "field": "name", "sortable": True},
+        {"name": "name", "label": t("col_orchestra"), "field": "name", "sortable": True, "align": "left"},
         {"name": "actions", "label": "", "field": "id", "align": "right"},
     ]
 
@@ -178,11 +178,11 @@ def _orchestras_panel(session) -> None:
 
 def _composers_panel(session, comp_refresh_hooks: list) -> None:
     columns = [
-        {"name": "last_name", "label": t("last_name"), "field": "last_name", "sortable": True},
-        {"name": "first_name", "label": t("first_name"), "field": "first_name"},
-        {"name": "birth_year", "label": t("birth_year"), "field": "birth_year"},
-        {"name": "death_year", "label": t("death_year"), "field": "death_year"},
-        {"name": "catalogue", "label": t("catalogue_label"), "field": "catalogue"},
+        {"name": "last_name", "label": t("last_name"), "field": "last_name", "sortable": True, "align": "left"},
+        {"name": "first_name", "label": t("first_name"), "field": "first_name", "align": "left"},
+        {"name": "birth_year", "label": t("birth_year"), "field": "birth_year", "align": "left"},
+        {"name": "death_year", "label": t("death_year"), "field": "death_year", "align": "left"},
+        {"name": "catalogue", "label": t("catalogue_label"), "field": "catalogue", "align": "left"},
         {"name": "actions", "label": "", "field": "id", "align": "right"},
     ]
 
@@ -302,9 +302,9 @@ def _composers_panel(session, comp_refresh_hooks: list) -> None:
 
 def _artists_panel(session) -> None:
     columns = [
-        {"name": "last_name", "label": t("last_name"), "field": "last_name", "sortable": True},
-        {"name": "first_name", "label": t("first_name"), "field": "first_name"},
-        {"name": "default_instrument", "label": t("default_instrument"), "field": "default_instrument"},
+        {"name": "last_name", "label": t("last_name"), "field": "last_name", "sortable": True, "align": "left"},
+        {"name": "first_name", "label": t("first_name"), "field": "first_name", "align": "left"},
+        {"name": "default_instrument", "label": t("default_instrument"), "field": "default_instrument", "align": "left"},
         {"name": "actions", "label": "", "field": "id", "align": "right"},
     ]
 
@@ -412,10 +412,10 @@ def _artists_panel(session) -> None:
 
 def _pieces_panel(session, comp_refresh_hooks: list) -> None:
     columns = [
-        {"name": "composer", "label": t("composer"), "field": "composer", "sortable": True},
-        {"name": "title", "label": t("piece_title"), "field": "title", "sortable": True},
-        {"name": "key", "label": t("key"), "field": "key"},
-        {"name": "catalogue_number", "label": t("catalogue_number"), "field": "catalogue_number"},
+        {"name": "composer", "label": t("composer"), "field": "composer", "sortable": True, "align": "left"},
+        {"name": "title", "label": t("piece_title"), "field": "title", "sortable": True, "align": "left"},
+        {"name": "key", "label": t("key"), "field": "key", "align": "left"},
+        {"name": "catalogue_number", "label": t("catalogue_number"), "field": "catalogue_number", "align": "left"},
         {"name": "actions", "label": "", "field": "id", "align": "right"},
     ]
 
@@ -559,9 +559,9 @@ def _pieces_panel(session, comp_refresh_hooks: list) -> None:
 
 def _venues_panel(session) -> None:
     columns = [
-        {"name": "name", "label": t("col_venue"), "field": "name", "sortable": True},
-        {"name": "city", "label": t("city"), "field": "city"},
-        {"name": "country", "label": t("country"), "field": "country"},
+        {"name": "name", "label": t("col_venue"), "field": "name", "sortable": True, "align": "left"},
+        {"name": "city", "label": t("city"), "field": "city", "align": "left"},
+        {"name": "country", "label": t("country"), "field": "country", "align": "left"},
         {"name": "actions", "label": "", "field": "id", "align": "right"},
     ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "konzertkatalog"
-version = "1.1.0"
+version = "1.1.1"
 description = "Personal classical concert archive"
 requires-python = ">=3.13"
 dependencies = [

--- a/uv.lock
+++ b/uv.lock
@@ -469,7 +469,7 @@ wheels = [
 
 [[package]]
 name = "konzertkatalog"
-version = "1.1.0"
+version = "1.1.1"
 source = { virtual = "." }
 dependencies = [
     { name = "loguru" },


### PR DESCRIPTION
- **Reference data tables** — all columns (Werke, Komponisten, Künstler,
  Orchester, Spielorte) were right-aligned by default due to Quasar's table
  default. Explicit `align: left` added to every content column. (#12, #16)
- **Notes line breaks** — newlines entered in the Notizen textarea were
  collapsed to a single line on the concert detail view. Both concert-level
  and piece-level notes now render with `whitespace-pre-wrap`. (#13)