### PR TITLE
feat: Werke editable — add tests + back-to-concerts button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,24 @@ All notable changes to KonzertKatalog are documented here.
 
 ---
 
+## [1.2.0] — 2026-04-26
+
+### Added
+
+- **Werke editable** — pieces in the Reference Data → Werke tab can now be
+  edited (title, key, catalogue number, composer) and deleted, matching the
+  behaviour of all other reference data tabs. Resolves #11 / #19.
+- **Back to concerts button** — a `← Concerts` button now appears in the
+  concert detail header, allowing users to return to the concert list after
+  viewing or creating a concert without having to use the nav bar.
+
+### Fixed / Tests
+
+- Added service-layer tests for `update_piece` and `delete_piece` to ensure
+  both operations are covered.
+
+---
+
 ## [1.1.1] — 2026-04-26
 
 ### Fixed

--- a/app/i18n.py
+++ b/app/i18n.py
@@ -29,6 +29,7 @@ _TRANSLATIONS: dict[str, dict[str, str]] = {
         "col_soloists": "Soloists",
         "col_choir": "Choir",
         # Concert detail
+        "back_to_concerts": "← Concerts",
         "conducted_by": "Conducted by",
         "choir": "Choir",
         "choir_director": "Choir Director",
@@ -140,6 +141,7 @@ _TRANSLATIONS: dict[str, dict[str, str]] = {
         "col_soloists": "Solisten",
         "col_choir": "Chor",
         # Concert detail
+        "back_to_concerts": "← Konzerte",
         "conducted_by": "Dirigent",
         "choir": "Chor",
         "choir_director": "Chordirektor",

--- a/app/views/concert_detail.py
+++ b/app/views/concert_detail.py
@@ -41,6 +41,10 @@ def concert_detail_page(concert_id: int) -> None:
 
         with ui.row().classes("gap-2 shrink-0"):
             ui.button(
+                t("back_to_concerts"),
+                on_click=lambda: ui.navigate.to("/concerts"),
+            ).props("flat")
+            ui.button(
                 t("edit"),
                 on_click=lambda: ui.navigate.to(f"/concerts/{concert_id}/edit"),
             ).props("outline")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "konzertkatalog"
-version = "1.1.1"
+version = "1.2.0"
 description = "Personal classical concert archive"
 requires-python = ">=3.13"
 dependencies = [

--- a/tests/services/test_piece_service.py
+++ b/tests/services/test_piece_service.py
@@ -1,5 +1,5 @@
 from app.models import Composer
-from app.services.piece_service import create_piece, list_pieces, search_pieces
+from app.services.piece_service import create_piece, delete_piece, list_pieces, search_pieces, update_piece
 
 
 def test_create_and_list_piece(session):
@@ -28,3 +28,31 @@ def test_search_pieces_by_composer_name(session):
     session.flush()
     create_piece(session, composer_id=composer.id, title="Winterreise")
     assert len(search_pieces(session, "Schubert")) == 1
+
+
+def test_update_piece_title(session):
+    composer = Composer(first_name="Franz", last_name="Liszt")
+    session.add(composer)
+    session.flush()
+    piece = create_piece(session, composer_id=composer.id, title="Original Title")
+    updated = update_piece(session, piece.id, title="Updated Title")
+    assert updated.title == "Updated Title"
+
+
+def test_update_piece_key_and_catalogue(session):
+    composer = Composer(first_name="Wolfgang", last_name="Mozart", catalogue="KV")
+    session.add(composer)
+    session.flush()
+    piece = create_piece(session, composer_id=composer.id, title="Symphony No. 40")
+    updated = update_piece(session, piece.id, key="G minor", catalogue_number="550")
+    assert updated.key == "G minor"
+    assert updated.catalogue_number == "550"
+
+
+def test_delete_piece(session):
+    composer = Composer(first_name="Franz", last_name="Liszt")
+    session.add(composer)
+    session.flush()
+    piece = create_piece(session, composer_id=composer.id, title="Piece to Delete")
+    delete_piece(session, piece.id)
+    assert not any(p.id == piece.id for p in list_pieces(session))


### PR DESCRIPTION
## Summary

- **Closes #11** (and duplicate #19 already closed): Werke (pieces) editing was already implemented in the reference data UI — this PR adds the missing service-layer tests that verify `update_piece` and `delete_piece` work correctly.
- **Side quest**: The concert detail page had no way to navigate back to the concerts list after saving. Adds a `← Concerts` flat button to the detail header (EN + DE translations included).

## Changes

- `tests/services/test_piece_service.py` — three new tests: `test_update_piece_title`, `test_update_piece_key_and_catalogue`, `test_delete_piece`
- `app/views/concert_detail.py` — back button added to the header action row
- `app/i18n.py` — `back_to_concerts` key in EN and DE
- `CHANGELOG.md` + `pyproject.toml` — bumped to v1.2.0

## Test plan

- [x] `uv run pytest tests/services/test_piece_service.py -v` — 6/6 pass
- [x] `uv run pytest tests/ --ignore=tests/e2e` — 56/56 pass
- [ ] Open a concert detail page and confirm the `← Concerts` button navigates back to `/concerts`
- [ ] Open Reference Data → Pieces tab, click the edit pencil on any row, change the title, save — verify the table updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)