### PR TITLE
fix: update quick filter functionality and relabeling, ensure session management, and add related tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,39 @@ All notable changes to KonzertKatalog are documented here.
 
 ---
 
+## [1.2.1] — 2026-04-26
+
+### Fixed
+
+- **Quick filter wired up** — the text input on the concerts list was not
+  triggering searches due to a wrong Vue event binding (`update:model-value`
+  with `GenericEventArguments` instead of `on_change` with
+  `ValueChangeEventArguments`). Typing in the field now actually filters the
+  list.
+- **Session not prematurely closed** — `session.close()` was called immediately
+  after the initial page render, before any user interaction. Subsequent
+  searches would silently fail. The session is now kept open for the lifetime
+  of the page (closed on disconnect, as intended).
+
+### Changed
+
+- **Quick filter relabelled** — placeholder changed from "Search composers,
+  artists, venues…" to "Quick filter…" (EN) / "Schnellfilter…" (DE) to reflect
+  its narrower scope vs. the dedicated search page.
+- **"Advanced search →" link** — a muted link next to the quick filter now
+  points directly to `/search` for users who need date-range or per-entity
+  filtering.
+
+### Tests
+
+- `test_concert_list_quick_filter_is_connected` — regression guard: proves the
+  filter input is actually wired up by asserting a no-match term empties the
+  table.
+- `test_concert_list_has_advanced_search_link` — verifies the "Advanced search"
+  link is present and href-targets `/search`.
+
+---
+
 ## [1.2.0] — 2026-04-26
 
 ### Added

--- a/app/i18n.py
+++ b/app/i18n.py
@@ -16,7 +16,8 @@ _TRANSLATIONS: dict[str, dict[str, str]] = {
         "search_placeholder": "Search…",
         # Concert list
         "add_concert": "+ Add Concert",
-        "search_concerts": "Search composers, artists, venues…",
+        "search_concerts": "Quick filter…",
+        "advanced_search": "Advanced search →",
         "no_results": "No concerts found.",
         "of_concerts": "concert(s)",
         "prev": "←",
@@ -128,7 +129,8 @@ _TRANSLATIONS: dict[str, dict[str, str]] = {
         "search_placeholder": "Suchen…",
         # Concert list
         "add_concert": "+ Konzert hinzufügen",
-        "search_concerts": "Komponisten, Künstler, Spielstätten suchen…",
+        "search_concerts": "Schnellfilter…",
+        "advanced_search": "Erweiterte Suche →",
         "no_results": "Keine Konzerte gefunden.",
         "of_concerts": "Konzert(e)",
         "prev": "←",

--- a/app/views/concerts_list.py
+++ b/app/views/concerts_list.py
@@ -62,11 +62,8 @@ def concerts_list_page() -> None:
         ui.navigate.to(f"/concerts/{concert_id}")
 
     with ui.row().classes("w-full items-center gap-4 mb-4"):
-        (
-            ui.input(placeholder=t("search_concerts"))
-            .classes("flex-1")
-            .on("update:model-value", on_search)
-        )
+        ui.input(placeholder=t("search_concerts"), on_change=on_search).classes("flex-1")
+        ui.link(t("advanced_search"), "/search").classes("text-sm text-gray-500 whitespace-nowrap")
         pagination_label = ui.label("").classes("text-sm text-gray-500")
         ui.button(t("add_concert"), on_click=lambda: ui.navigate.to("/concerts/new")).props(
             "color=primary"
@@ -88,4 +85,3 @@ def concerts_list_page() -> None:
         ui.button(t("next"), on_click=next_page).props("flat")
 
     load()
-    session.close()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "konzertkatalog"
-version = "1.2.0"
+version = "1.2.1"
 description = "Personal classical concert archive"
 requires-python = ">=3.13"
 dependencies = [

--- a/tests/e2e/test_concert_e2e.py
+++ b/tests/e2e/test_concert_e2e.py
@@ -148,3 +148,35 @@ async def test_concert_list_search_by_orchestra(user: User) -> None:
     fire_value_change(user, search_input, 'XYZ_NO_MATCH')
     rows_no_match = _get_table_rows(user)
     assert not rows_no_match, f"Expected 0 results for 'XYZ_NO_MATCH', got: {rows_no_match}"
+
+
+async def test_concert_list_quick_filter_is_connected(user: User) -> None:
+    """Quick filter input is wired up: a no-match term empties the table."""
+    await user.open('/concerts')
+    rows_before = _get_table_rows(user)
+    assert rows_before, "Seeded DB should have at least one concert"
+
+    with user:
+        search_inputs = list(ElementFilter(kind=ui.input, only_visible=True))
+        search_input = search_inputs[0]
+
+    fire_value_change(user, search_input, 'ZZZ_NOTHING_MATCHES_THIS')
+    rows_after = _get_table_rows(user)
+    assert not rows_after, (
+        "Quick filter has no effect — event binding is likely broken "
+        f"(got {len(rows_after)} rows, expected 0)"
+    )
+
+
+async def test_concert_list_has_advanced_search_link(user: User) -> None:
+    """Concerts list shows an 'Advanced search' link pointing to /search."""
+    await user.open('/concerts')
+    await user.should_see('Advanced search →')
+
+    with user:
+        links = list(ElementFilter(kind=ui.link))
+    search_links = [lnk for lnk in links if 'Advanced search' in (lnk.text or '')]
+    assert search_links, "No ui.link with 'Advanced search' found"
+    assert any(lnk._props.get('href') == '/search' for lnk in search_links), (
+        f"Expected link href '/search', got: {[lnk._props.get('href') for lnk in search_links]}"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -469,7 +469,7 @@ wheels = [
 
 [[package]]
 name = "konzertkatalog"
-version = "1.1.1"
+version = "1.2.1"
 source = { virtual = "." }
 dependencies = [
     { name = "loguru" },


### PR DESCRIPTION
- **Quick filter wired up** — the text input on the concerts list was not
  triggering searches due to a wrong Vue event binding (`update:model-value`
  with `GenericEventArguments` instead of `on_change` with
  `ValueChangeEventArguments`). Typing in the field now actually filters the
  list.
- **Session not prematurely closed** — `session.close()` was called immediately
  after the initial page render, before any user interaction. Subsequent
  searches would silently fail. The session is now kept open for the lifetime
  of the page (closed on disconnect, as intended).