### PR TITLE
feat: update PDF attachment handling to open in new tab, add image type detection, and implement related tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to KonzertKatalog are documented here.
 
 ---
 
+## [1.2.2] — 2026-04-26
+
+### Fixed
+
+- **PDF attachments openable** — clicking a PDF (or any non-image) attachment
+  in the concert detail view now opens the file in a new browser tab instead of
+  showing a blank lightbox dialog. Images continue to open in the in-page
+  lightbox as before. Non-image thumbnails now display a document icon so users
+  can recognise the file type at a glance. Resolves #10.
+
+### Tests
+
+- `test_is_image_returns_true_for_image_extensions` — parametrised over common
+  image extensions (jpg, jpeg, png, gif, webp, bmp, svg) including mixed case.
+- `test_is_image_returns_false_for_non_image_files` — parametrised over pdf,
+  docx, txt, zip and extension-less filenames.
+- `test_is_image_strips_path_components` — verifies path prefixes do not
+  interfere with the extension check.
+- `test_is_image_timestamped_pdf_filename` — exercises the real-world filename
+  pattern produced by the upload handler.
+
+---
+
 ## [1.2.1] — 2026-04-26
 
 ### Fixed

--- a/app/views/concert_detail.py
+++ b/app/views/concert_detail.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 from loguru import logger
 from nicegui import ui
 
@@ -6,6 +8,13 @@ from app.i18n import t
 from app.models import AttachmentType
 from app.services.concert_service import delete_concert, get_concert
 from app.storage.file_handler import url_for_upload
+
+_IMAGE_EXTENSIONS = {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp", ".svg"}
+
+
+def _is_image(filename: str) -> bool:
+    """Return True if *filename* has a recognised image extension."""
+    return Path(filename).suffix.lower() in _IMAGE_EXTENSIONS
 
 
 def concert_detail_page(concert_id: int) -> None:
@@ -116,11 +125,19 @@ def concert_detail_page(concert_id: int) -> None:
 
 
 def _image_thumbnail(url: str, label: str) -> None:
-    with ui.card().classes("cursor-pointer").on(
-        "click", lambda u=url, lbl=label: _open_lightbox(u, lbl)
-    ):
-        ui.image(url).classes("w-40 h-40 object-cover")
-        ui.label(label).classes("text-xs text-gray-500 truncate max-w-40")
+    if _is_image(label):
+        with ui.card().classes("cursor-pointer").on(
+            "click", lambda u=url, lbl=label: _open_lightbox(u, lbl)
+        ):
+            ui.image(url).classes("w-40 h-40 object-cover")
+            ui.label(label).classes("text-xs text-gray-500 truncate max-w-40")
+    else:
+        with ui.card().classes("cursor-pointer").on(
+            "click", lambda u=url: ui.navigate.to(u, new_tab=True)
+        ):
+            with ui.element("div").classes("w-40 h-40 flex items-center justify-center"):
+                ui.icon("description").classes("text-6xl text-gray-400")
+            ui.label(label).classes("text-xs text-gray-500 truncate max-w-40")
 
 
 def _open_lightbox(url: str, label: str) -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "konzertkatalog"
-version = "1.2.1"
+version = "1.2.2"
 description = "Personal classical concert archive"
 requires-python = ">=3.13"
 dependencies = [

--- a/tests/views/test_concert_detail.py
+++ b/tests/views/test_concert_detail.py
@@ -1,0 +1,53 @@
+"""Tests for concert detail view helpers."""
+
+import pytest
+
+from app.views.concert_detail import _is_image
+
+
+# ---------------------------------------------------------------------------
+# _is_image — pure helper that drives the image vs. document rendering path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("filename", [
+    "photo.jpg",
+    "photo.JPG",
+    "scan.jpeg",
+    "scan.JPEG",
+    "screenshot.png",
+    "screenshot.PNG",
+    "animation.gif",
+    "animation.GIF",
+    "thumbnail.webp",
+    "thumbnail.WEBP",
+    "image.bmp",
+    "vector.svg",
+])
+def test_is_image_returns_true_for_image_extensions(filename):
+    assert _is_image(filename) is True
+
+
+@pytest.mark.parametrize("filename", [
+    "review.pdf",
+    "review.PDF",
+    "programme.PDF",
+    "ticket.docx",
+    "notes.txt",
+    "archive.zip",
+    "noextension",
+    "",
+])
+def test_is_image_returns_false_for_non_image_files(filename):
+    assert _is_image(filename) is False
+
+
+def test_is_image_strips_path_components():
+    """Only the file extension matters — path prefixes must not interfere."""
+    assert _is_image("2024/ticket/abc123_scan.jpg") is True
+    assert _is_image("2024/review/abc123_notes.pdf") is False
+
+
+def test_is_image_timestamped_pdf_filename():
+    """Realistic stored filename from a concert attachment upload."""
+    assert _is_image("2025-05-12T14_35_15Z 849_RHB_EN.pdf") is False

--- a/uv.lock
+++ b/uv.lock
@@ -469,7 +469,7 @@ wheels = [
 
 [[package]]
 name = "konzertkatalog"
-version = "1.2.1"
+version = "1.2.2"
 source = { virtual = "." }
 dependencies = [
     { name = "loguru" },


### PR DESCRIPTION
- **PDF attachments openable** — clicking a PDF (or any non-image) attachment
  in the concert detail view now opens the file in a new browser tab instead of
  showing a blank lightbox dialog. Images continue to open in the in-page
  lightbox as before. Non-image thumbnails now display a document icon so users
  can recognise the file type at a glance. Resolves #10.…