### PR TITLE
feat: enhance artist search to include all roles in filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to KonzertKatalog are documented here.
 
 ---
 
+## [1.3.0] — 2026-04-26
+
+### Fixed
+
+- **Artist search covers all roles** — filtering concerts by artist in the
+  advanced search page now returns concerts where that person appears as
+  conductor or choir director, not only as a soloist. Previously an artist like
+  Florian Donderer (registered with a default instrument) was invisible in
+  search results when he had conducted a concert. Resolves #17.
+
+---
+
 ## [1.2.2] — 2026-04-26
 
 ### Fixed

--- a/app/services/concert_service.py
+++ b/app/services/concert_service.py
@@ -162,7 +162,13 @@ def _filter_query(
     if conductor_id is not None:
         stmt = stmt.where(Concert.conductor_id == conductor_id)
     if artist_id is not None:
-        stmt = stmt.where(Artist.id == artist_id)
+        stmt = stmt.where(
+            or_(
+                Artist.id == artist_id,
+                Concert.conductor_id == artist_id,
+                Concert.choir_director_id == artist_id,
+            )
+        )
     if orchestra_id is not None:
         stmt = stmt.where(Concert.orchestra_id == orchestra_id)
     if venue_id is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "konzertkatalog"
-version = "1.2.2"
+version = "1.3.0"
 description = "Personal classical concert archive"
 requires-python = ">=3.13"
 dependencies = [

--- a/tests/services/test_concert_service.py
+++ b/tests/services/test_concert_service.py
@@ -6,6 +6,7 @@ from app.models import Artist, Composer, Piece, Venue
 from app.services.concert_service import (
     create_concert,
     delete_concert,
+    filter_concerts,
     get_concert,
     list_concerts,
     update_concert,
@@ -104,3 +105,82 @@ def test_create_concert_with_pieces_and_artists(session, seed):
     assert len(concert.piece_links) == 1
     assert len(concert.artist_links) == 1
     assert concert.piece_links[0].sort_order == 1
+
+
+# ---------------------------------------------------------------------------
+# filter_concerts — artist_id must match across all roles (issue #17)
+# ---------------------------------------------------------------------------
+
+
+def test_filter_by_artist_id_finds_concert_where_artist_is_conductor(session):
+    """Filtering by artist_id must include concerts where that artist is conductor."""
+    donderer = Artist(first_name="Florian", last_name="Donderer", default_instrument="Violin")
+    session.add(donderer)
+    session.flush()
+    concert = create_concert(session, date=date(2024, 3, 15), conductor_id=donderer.id)
+
+    results = filter_concerts(session, artist_id=donderer.id)
+
+    assert any(c.id == concert.id for c in results), (
+        "Concert where the artist is conductor was not returned when filtering by artist_id"
+    )
+
+
+def test_filter_by_artist_id_finds_concert_where_artist_is_choir_director(session):
+    """Filtering by artist_id must include concerts where that artist is choir director."""
+    donderer = Artist(first_name="Florian", last_name="Donderer", default_instrument="Violin")
+    session.add(donderer)
+    session.flush()
+    concert = create_concert(
+        session,
+        date=date(2024, 4, 10),
+        choir="Stadtchor",
+        choir_director_id=donderer.id,
+    )
+
+    results = filter_concerts(session, artist_id=donderer.id)
+
+    assert any(c.id == concert.id for c in results), (
+        "Concert where the artist is choir director was not returned when filtering by artist_id"
+    )
+
+
+def test_filter_by_artist_id_still_finds_soloist(session):
+    """Existing soloist behaviour must remain: artist linked via ConcertArtist is still found."""
+    donderer = Artist(first_name="Florian", last_name="Donderer", default_instrument="Violin")
+    session.add(donderer)
+    session.flush()
+    concert = create_concert(
+        session,
+        date=date(2024, 5, 1),
+        artists=[{"artist_id": donderer.id, "role": "Soloist"}],
+    )
+
+    results = filter_concerts(session, artist_id=donderer.id)
+
+    assert any(c.id == concert.id for c in results), (
+        "Concert where the artist is a soloist was not returned — regression in existing behaviour"
+    )
+
+
+def test_filter_by_artist_id_returns_all_roles_and_excludes_unrelated(session):
+    """Artist in multiple roles → both concerts returned; unrelated concert excluded."""
+    donderer = Artist(first_name="Florian", last_name="Donderer", default_instrument="Violin")
+    other = Artist(first_name="Other", last_name="Conductor")
+    session.add_all([donderer, other])
+    session.flush()
+
+    c_conductor = create_concert(session, date=date(2024, 1, 1), conductor_id=donderer.id)
+    c_soloist = create_concert(
+        session,
+        date=date(2024, 2, 1),
+        artists=[{"artist_id": donderer.id, "role": "Soloist"}],
+    )
+    c_unrelated = create_concert(session, date=date(2024, 3, 1), conductor_id=other.id)
+
+    results = filter_concerts(session, artist_id=donderer.id)
+    result_ids = {c.id for c in results}
+
+    assert c_conductor.id in result_ids
+    assert c_soloist.id in result_ids
+    assert c_unrelated.id not in result_ids


### PR DESCRIPTION
- **Artist search covers all roles** — filtering concerts by artist in the
  advanced search page now returns concerts where that person appears as
  conductor or choir director, not only as a soloist. Previously an artist like
  Florian Donderer (registered with a default instrument) was invisible in
  search results when he had conducted a concert. Resolves #17.